### PR TITLE
Harden GitHub Actions workflows (low-risk)

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -21,7 +21,9 @@ jobs:
     env:
       MDBOOK_VERSION: 0.4.36
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Install mdBook
         run: |
           curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
@@ -31,7 +33,7 @@ jobs:
         run: npm install static-sitemap-cli
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Build with mdBook
         run: mdbook build
       - name: Generate sitemap
@@ -40,7 +42,7 @@ jobs:
           cd book
           npx sscli --no-clean --base https://howtowincptc.com
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./book
 
@@ -53,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary

Conservative, low-risk hardening of `.github/workflows/mdbook.yml`. No changes to triggers, the workflow-level `permissions:` block, or any deploy-step logic.

### Changes applied (LOW-RISK only)
- **Pin all `uses:` to commit SHAs** (via `pinact`), retaining `# vX` comments — clears 4 `unpinned-uses` (High):
  - `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - `actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0`
  - `actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1`
  - `actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5`
- **`persist-credentials: false`** on `actions/checkout` — clears 1 `artipacked` (Medium). No later step performs git ops with the token (only `mdbook build` + artifact upload).

### zizmor before → after
| | Before | After |
|---|--------|-------|
| `unpinned-uses` (High) | 4 | **0** |
| `artipacked` (Medium) | 1 | **0** |
| `excessive-permissions` (High) | 2 | **2 (intentionally remain)** |
| **Total surfaced** | 7 | **2** |

**actionlint:** clean (exit 0) before and after.

### Intentionally deferred (NOT in this PR)
The 2 `excessive-permissions` (High) findings — scoping `pages: write` / `id-token: write` from the workflow level down to the `deploy` job — are **intentionally deferred** as higher-risk. They modify the privilege model of the **only deploy path**, which is a **production GitHub Pages deploy** (`push` to `main` / `workflow_dispatch`) with **no `pull_request` trigger** — i.e. **not PR-testable**. A permission-scoping regression would only surface on a live production deploy, so it warrants separate, manually-approved handling (e.g. a `workflow_dispatch` smoke test). The `permissions:` block is left exactly as-is here.

All changes are byte-level/mechanical, independently revertible, and leave triggers, permissions, and the Pages publish mechanism unchanged.