### PR TITLE
ci: scope Pages permissions to the deploy job (least privilege)

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 
 concurrency:
@@ -47,6 +45,9 @@ jobs:
           path: ./book
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Least-privilege Pages permissions

Resolves zizmor `excessive-permissions` findings (2 high) by scoping write permissions to only the job that needs them.

### Change
- Workflow-level `permissions:` reduced to just `contents: read`.
- The `deploy` job gets its own `permissions:` block with `pages: write` + `id-token: write` — exactly what `actions/deploy-pages` requires.
- The `build` job inherits `contents: read` (sufficient to checkout + `mdbook build` + `configure-pages`/`upload-pages-artifact`, none of which need write).

### Why
Previously the build job inherited `pages: write` and `id-token: write` it never uses. Restricting those to the deploy job follows the documented least-privilege GitHub Pages pattern.

No changes to triggers, steps, concurrency, or SHA pins. Production deploys to GitHub Pages on merge to `main`.